### PR TITLE
Remove a double warning about console.log

### DIFF
--- a/dbos-rules.ts
+++ b/dbos-rules.ts
@@ -385,7 +385,6 @@ const baseConfig = {
   rules: {
     "no-eval": "error",
     "@typescript-eslint/no-implied-eval": "error",
-    "no-console": "error",
     "security/detect-unsafe-regex": "error",
     "no-secrets/no-secrets": "error",
     "@dbos-inc/detect-nondeterministic-calls": "error"
@@ -432,7 +431,7 @@ const extConfig = {
 module.exports = {
   meta: {
     name: "@dbos-inc/eslint-plugin",
-    version: "1.0.4"
+    version: "1.0.5"
   },
 
   rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dbos-inc/eslint-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dbos-inc/eslint-plugin",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.14.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbos-inc/eslint-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "eslint plugin for DBOS SDK",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Having the other rule for detecting `console.log` was redundant